### PR TITLE
Dashboard

### DIFF
--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Dashboard v3.15.41 | 2026-05-04
+
+## New
+- None
+
+## Enhancements
+- None
+
+## Fixes
+- Fixed pagination issues across all three Moderation Log tabs (Flagged, Blocked, Reviewed) — including NaN total counts, cross-tab state interference, stale data accumulation, and filter/date range not persisting across pages.
+- Fixed an issue where creating a new app via the AI Agent platform opened the builder in a new tab with broken UI instead of the deploy screen.
+- Fixed the agent builder always displaying a loading screen when launching under deploy after creating a new app via AI Agents.
+- Fixed the Token TTL input row not being displayed on the Messages Settings page when presigned is the only available file-access option.
+<br>
+
 # Dashboard v3.15.40 | 2026-04-14
 
 ## New

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updated the React UI Kit to version 6.4.2 and Calls SDK to version 4.2.5 across the UI Kit Builder, Widget Builder, Dashboard, and Preview for improved stability and consistency.
 
 ## Fixes
-- None
+- Fixed an issue in call logs pagination where navigation beyond page 10 was not working.
 <br>
 
 # Dashboard v3.15.38 | 2026-04-02

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Dashboard v3.15.40 | 2026-04-14
+
+## New
+- None
+
+## Enhancements
+- None
+
+## Fixes
+- Fixed an issue where refreshing the Groups page resulted in an endless loading state instead of displaying the groups list.
+- Fixed an issue where the "Fetching more details" message remained visible indefinitely on the Chats page instead of disappearing after data was retrieved or after a timeout period.
+- Fixed an error where refreshing any page and immediately clicking on another tab would throw "App with app id undefined does not exist or you do not have access to it" and redirect to the app list page.
+- Fixed multiple API calls being triggered when clicking next on pagination in user and group components.
+- Fixed an infinite re-render loop on the Roles detail page that occurred when a multi-tenant child app referenced a parent app that no longer exists.
+<br>
+
 # Dashboard v3.15.39 | 2026-04-08
 
 ## New

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Dashboard v3.15.41 | 2026-05-05
 
 ## New
-- Added AI Agent Skill as a new integration option on the Chat & Messaging Get Started page. AI assistants (Claude Code, Cursor, Copilot, etc.) can now run npx @cometchat/skills add to automatically set up the SDK and UI Kit. Supported across React, React Router, Next.js, React Native, Angular, Android, iOS, Flutter, and Others tabs.
+- Added AI Agent Skill as a new integration option on the Chat & Messaging Get Started page. AI assistants (Claude Code, Cursor, Copilot, etc.) can now run `npx skills add cometchat/cometchat-skills` add to automatically set up the SDK and UI Kit. Supported across React, React Router, Next.js, React Native, Angular, Android, iOS, Flutter, and Others tabs.
 
 ## Enhancements
 - None

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Dashboard v3.15.41 | 2026-05-05
 
 ## New
-- None
+- Added AI Agent Skill as a new integration option on the Chat & Messaging Get Started page. AI assistants (Claude Code, Cursor, Copilot, etc.) can now run npx @cometchat/skills add to automatically set up the SDK and UI Kit. Supported across React, React Router, Next.js, React Native, Angular, Android, iOS, Flutter, and Others tabs.
 
 ## Enhancements
 - None
@@ -11,6 +11,9 @@
 - Fixed an issue where creating a new app via the AI Agent platform opened the builder in a new tab with broken UI instead of the deploy screen.
 - Fixed the agent builder always displaying a loading screen when launching under deploy after creating a new app via AI Agents.
 - Fixed the Token TTL input row not being displayed on the Messages Settings page when presigned is the only available file-access option.
+- Fixed members list overflow inside the Add Members popup on the Groups page.
+- Fixed multiple loaders being visible on the Get Started page of Chat & Messaging when refreshing the page.
+- Fixed call logs list failing to load after refreshing the call detail page and navigating back to the list page.
 <br>
 
 # Dashboard v3.15.40 | 2026-04-14

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Dashboard v3.15.39 | 2026-04-08
 
 ## New
-- Introduced a compact message composer toggle in the Layout settings, allowing users to switch between compact (single-line) and multi-line message composer modes.
-- Added a toggle to enable or disable rich text formatting in the core messaging experience (enabled by default).
+- Added support for the compact message composer in the UI Kit Builder, Widget Builder, and Preview, enabling switching between single-line and multi-line message composition.
+- Added support for rich text formatting in the UI Kit Builder, Widget Builder, and Preview, enabling users to toggle rich text formatting in the core messaging experience. This feature is enabled by default.
 
 ## Enhancements
 - Updated the React UI Kit to version 6.4.2 and Calls SDK to version 4.2.5 across the UI Kit Builder, Widget Builder, Dashboard, and Preview for improved stability and consistency.

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Dashboard v3.15.41 | 2026-05-04
+# Dashboard v3.15.41 | 2026-05-05
 
 ## New
 - None

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New
 - Introduced notification templates for @user mentions, enabling customization of push notifications sent to mentioned users.
 - Introduced notification templates for @all mentions, enabling customization of push notifications for group mentions.
+- Added a new "Intent Selection" step to the onboarding flow, allowing users to indicate whether they are building, evaluating, or exploring CometChat. This step appears after role selection and before application creation.
 
 ## Enhancements
 - None

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Dashboard v3.15.39 | 2026-04-06
+# Dashboard v3.15.39 | 2026-04-08
 
 ## New
 - Introduced a compact message composer toggle in the Layout settings, allowing users to switch between compact (single-line) and multi-line message composer modes.
+- Added a toggle to enable or disable rich text formatting in the core messaging experience (enabled by default).
 
 ## Enhancements
 - Updated the React UI Kit to version 6.4.2 and Calls SDK to version 4.2.5 across the UI Kit Builder, Widget Builder, Dashboard, and Preview for improved stability and consistency.

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Dashboard v3.15.39 | 2026-04-06
+
+## New
+- Introduced a compact message composer toggle in the Layout settings, allowing users to switch between compact (single-line) and multi-line message composer modes.
+
+## Enhancements
+- Updated the React UI Kit to version 6.4.2 and Calls SDK to version 4.2.5 across the UI Kit Builder, Widget Builder, Dashboard, and Preview for improved stability and consistency.
+
+## Fixes
+- None
+<br>
+
 # Dashboard v3.15.38 | 2026-04-02
 
 ## New

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Dashboard v3.15.40 | 2026-04-14
 
 ## New
-- None
+- Introduced notification templates for @user mentions, enabling customization of push notifications sent to mentioned users.
+- Introduced notification templates for @all mentions, enabling customization of push notifications for group mentions.
 
 ## Enhancements
 - None

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ## Fixes
 - Fixed pagination issues across all three Moderation Log tabs (Flagged, Blocked, Reviewed) — including NaN total counts, cross-tab state interference, stale data accumulation, and filter/date range not persisting across pages.
-- Fixed an issue where creating a new app via the AI Agent platform opened the builder in a new tab with broken UI instead of the deploy screen.
-- Fixed the agent builder always displaying a loading screen when launching under deploy after creating a new app via AI Agents.
+- Fixed an issue where creating a new app via the AI Agent platform incorrectly opened the builder in a new tab instead of navigating to the deploy screen.
+- Fixed the Deploy tab in AI Agents showing an infinite loading screen instead of the integration options after creating a new app.
 - Fixed the Token TTL input row not being displayed on the Messages Settings page when presigned is the only available file-access option.
 - Fixed members list overflow inside the Add Members popup on the Groups page.
 - Fixed multiple loaders being visible on the Get Started page of Chat & Messaging when refreshing the page.

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Dashboard v3.15.42 | 2026-05-11
 
 ## New
+- Added Unreal Engine as a new SDK platform option in the onboarding flow and as a tab on the Chat & Messaging → Get Started / Integrate page, with a dedicated Unreal SDK card linking to the documentation.
+
+- Added Skills mode in the UI Kit Builder: when the builder is opened via the CometChat Skills CLI deep link `(?flow=cli)`, the header displays a  "Done Editing" button. Clicking "Done Editing" shows a confirmation modal, letting users know they can return to their terminal.
+
+## Enhancements
+- None
+
+## Fixes
+- None
+
+# Dashboard v3.15.42 | 2026-05-11
+
+## New
 - None
 
 ## Enhancements

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Dashboard v3.15.42 | 2026-05-11
+# Dashboard v3.15.43 | 2026-05-27
 
 ## New
 - Added Unreal Engine as a new SDK platform option in the onboarding flow and as a tab on the Chat & Messaging → Get Started / Integrate page, with a dedicated Unreal SDK card linking to the documentation.

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Dashboard v3.15.42 | 2026-05-08
+
+## New
+- None
+
+## Enhancements
+- Updated the AI Agent Skill terminal command from `npx skills add cometchat/cometchat-skills` to `npx @cometchat/skills add` on the Chat & Messaging Get Started page.
+
+## Fixes
+- Fixed pagination layout issue in the Add Members popup on the Groups page.
+- Fixed the screen reloading twice when navigating back from Logs to the Chat & Messaging page.
+- Fixed the Add Members modal in Groups showing a blank user list on open and not responding to single-character search.
+- Fixed the AI Agent Widget preview growing beyond its container as messages increase. The message list now scrolls within a fixed-height container instead of expanding the widget.
+
 # Dashboard v3.15.41 | 2026-05-05
 
 ## New

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -4,11 +4,11 @@
 - None
 
 ## Enhancements
-- Updated the AI Agent Skill terminal command from `npx skills add cometchat/cometchat-skills` to `npx @cometchat/skills add` on the Chat & Messaging Get Started page.
+- Updated the AI Agent Skill terminal command from `npx skills add cometchat/cometchat-skills` to `npx @cometchat/skills add` on the Chat & Messaging -> Get Started / Integrate page.
 
 ## Fixes
 - Fixed pagination layout issue in the Add Members popup on the Groups page.
-- Fixed the screen reloading twice when navigating back from Logs to the Chat & Messaging page.
+- Fixed the screen reloading twice when navigating back from Chat & Messaging -> Logs to the Get Started / Integrate page.
 - Fixed the Add Members modal in Groups showing a blank user list on open and not responding to single-character search.
 - Fixed the AI Agent Widget preview growing beyond its container as messages increase. The message list now scrolls within a fixed-height container instead of expanding the widget.
 <br>

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - Added Skills mode in the UI Kit Builder: when the builder is opened via the CometChat Skills CLI deep link `(?flow=cli)`, the header displays a  "Done Editing" button. Clicking "Done Editing" shows a confirmation modal, letting users know they can return to their terminal.
 
+- Campaigns — Create, schedule, and send templated notifications to users via in-app feed and push, with per-recipient variable substitution and real-time delivery tracking.
+
+
 ## Enhancements
 - None
 

--- a/dashboard/CHANGELOG.md
+++ b/dashboard/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Dashboard v3.15.42 | 2026-05-08
+# Dashboard v3.15.42 | 2026-05-11
 
 ## New
 - None
@@ -11,6 +11,7 @@
 - Fixed the screen reloading twice when navigating back from Logs to the Chat & Messaging page.
 - Fixed the Add Members modal in Groups showing a blank user list on open and not responding to single-character search.
 - Fixed the AI Agent Widget preview growing beyond its container as messages increase. The message list now scrolls within a fixed-height container instead of expanding the widget.
+<br>
 
 # Dashboard v3.15.41 | 2026-05-05
 


### PR DESCRIPTION
## New
- Added Unreal Engine as a new SDK platform option in the onboarding flow and as a tab on the Chat & Messaging → Get Started / Integrate page, with a dedicated Unreal SDK card linking to the documentation.

- Added Skills mode in the UI Kit Builder: when the builder is opened via the CometChat Skills CLI deep link `(?flow=cli)`, the header displays a  "Done Editing" button. Clicking "Done Editing" shows a confirmation modal, letting users know they can return to their terminal.

- Campaigns — Create, schedule, and send templated notifications to users via in-app feed and push, with per-recipient variable substitution and real-time delivery tracking.

## Enhancements
- None

## Fixes
- None
