### PR TITLE
Update CHANGELOG for v3.13.1 fixes

### DIFF
--- a/chat-api/CHANGELOG.md
+++ b/chat-api/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Chat API v3.13.1 | 2026-08-05
+
+## New
+- None
+
+## Enhancements
+- None
+
+## Fixes
+- Fixed an issue where a quoted message that was later edited and blocked by moderation remained visible to receivers inside the quote.
+  
 # Chat API v3.13.0 | 2026-06-12
 
 ## New


### PR DESCRIPTION
Fixed an issue where a quoted message that was later edited and blocked by moderation remained visible to receivers inside the quote.